### PR TITLE
Changed userId to be an ObjectId.

### DIFF
--- a/web/src/app/api/auth/google/link-telegram/route.ts
+++ b/web/src/app/api/auth/google/link-telegram/route.ts
@@ -153,7 +153,7 @@ export async function POST(req: NextRequest) {
     // 4. Check if Telegram user already has a Google account linked
     console.log("[Link Telegram] Step 4: Checking for existing Google link on Telegram user:", telegramUserId);
     const existingLink = await db.collection("accounts").findOne({
-      userId: telegramUserId,
+      userId: new ObjectId(telegramUserId),
       provider: "google",
     });
 
@@ -198,7 +198,7 @@ export async function POST(req: NextRequest) {
       { _id: googleAccount._id },
       {
         $set: {
-          userId: telegramUserId,
+          userId: new ObjectId(telegramUserId),
           updatedAt: new Date(),
         },
       }

--- a/web/src/lib/google-tokens.ts
+++ b/web/src/lib/google-tokens.ts
@@ -1,6 +1,7 @@
 import { google } from "googleapis";
 import { getMongoClient } from "@/lib/db";
 import { env } from "@/env";
+import { ObjectId } from "mongodb";
 
 export interface GoogleTokens {
   accessToken: string;
@@ -9,7 +10,7 @@ export interface GoogleTokens {
 }
 
 interface GoogleAccountDocument {
-  userId: string;
+  userId: ObjectId;
   type: string;
   provider: string;
   providerAccountId: string;
@@ -83,7 +84,7 @@ export async function getUserGoogleTokens(
 
     // Find Google account for this user
     const account = await accountsCollection.findOne({
-      userId,
+      userId: new ObjectId(userId),
       provider: "google",
     });
 
@@ -103,7 +104,7 @@ export async function getUserGoogleTokens(
 
       // Update DB with new token
       await accountsCollection.updateOne(
-        { userId, provider: "google" },
+        { userId: new ObjectId(userId), provider: "google" },
         {
           $set: {
             access_token: accessToken,
@@ -146,7 +147,7 @@ export async function refreshUserGoogleToken(
       client.db().collection<GoogleAccountDocument>("accounts");
 
     const account = await accountsCollection.findOne({
-      userId,
+      userId: new ObjectId(userId),
       provider: "google",
     });
 
@@ -162,7 +163,7 @@ export async function refreshUserGoogleToken(
 
     // Update DB
     await accountsCollection.updateOne(
-      { userId, provider: "google" },
+      { userId: new ObjectId(userId), provider: "google" },
       {
         $set: {
           access_token: accessToken,


### PR DESCRIPTION
The userId in Google accounts was stored as strings when linking Telegram to Google, but the Google accounts created in the web app stored them as ObjectId, which caused  getUserGoogleTokens() function to fail finding the web accounts.